### PR TITLE
Feat: 롤 검색

### DIFF
--- a/src/api/game/GameApi.jsx
+++ b/src/api/game/GameApi.jsx
@@ -16,6 +16,11 @@ export const getDnfInfo = async (params) => {
     return ApiService.get('/api/game/dnf', params)
 }
 
+export const getLolInfo = async (params) => {
+    return ApiService.get('/api/game/lol', params)
+}
+
+
 export const mergeFavorites = async (params) => {
     return ApiService.post('/api/game/favorites', {params})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 롤(LoL) 소환사 검색을 지원합니다. 닉네임을 “이름#태그” 형식으로 입력해 조회할 수 있습니다.
  - 검색 결과 카드에 프로필 아이콘, 소환사 레벨, 닉네임을 표시합니다.
  - 즐겨찾기 버튼으로 해당 소환사를 추가/해제할 수 있으며, 변경 후 목록이 자동으로 새로고침됩니다.
  - 카드 선택 시 상세 화면으로 이동할 수 있습니다.
  - 라디오 선택에 ‘롤’ 옵션이 추가되어 게임별 검색 전환이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->