### PR TITLE
Fix: 즐겨찾기, 강화수치 수정

### DIFF
--- a/src/pagrs/Home.jsx
+++ b/src/pagrs/Home.jsx
@@ -302,7 +302,7 @@ function Home() {
                                                             size="sm"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
-                                                                favoriteUpdate(2, character.characterId);
+                                                                favoriteUpdate(1, character.characterId);
                                                             }}
                                                         >
                                                             {character.favorite ? "⭐" : "☆"}

--- a/src/pagrs/game/Dnf.jsx
+++ b/src/pagrs/game/Dnf.jsx
@@ -609,7 +609,7 @@ const  Dnf = ({ gameKey, subVal }) => {
                                                 <span>{item.itemName || '장착 없음'}</span>
                                                 {item.reinforce && item.reinforce > 0 && (
                                                     <span style={{
-                                                        backgroundColor: '#e91e63',
+                                                        backgroundColor: item.amplificationName !== null ? '#e91e63' : '#2196f3',
                                                         color: 'white',
                                                         fontSize: '11px',
                                                         fontWeight: 'bold',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 던파 즐겨찾기 버튼이 올바른 게임 타입으로 즐겨찾기를 업데이트하도록 동작을 수정했습니다. 잘못된 게임 타입으로 처리되던 문제를 해결하여 즐겨찾기 반영이 정확해졌습니다.
- 스타일
  - 던파 장비 탭의 강화 배지 색상을 조건부로 표시합니다. 증폭이 있을 때는 핑크/레드, 없을 때는 블루로 보여 시각적 구분이 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->